### PR TITLE
Add view iterators to improve ergonomics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ## Next
 
 * Changed crate structure to separate `substreams-ethereum-core` from `substreams-ethereum`.
+* Added helpers to `pb::Block` and `pb::TransactionTrace` to facilitate iterating over events.
+* Removed `Event::must_decode`, use the new `Event::match_and_decode` instead.
 
 ## [v0.1.4](https://github.com/streamingfast/substreams-ethereum/releases/tag/0.1.4)
 

--- a/abigen-tests/src/abi/tests.rs
+++ b/abigen-tests/src/abi/tests.rs
@@ -66,10 +66,12 @@
                             &[ethabi::ParamType::Address],
                             log.topics[1usize].as_ref(),
                         )
-                        .map_err(|e| format!(
-                            "unable to decode param 'first' from topic of type 'address': {}",
-                            e
-                        ))?
+                        .map_err(|e| {
+                            format!(
+                                "unable to decode param 'first' from topic of type 'address': {}",
+                                e
+                            )
+                        })?
                         .pop()
                         .expect(INTERNAL_ERR)
                         .into_address()
@@ -159,10 +161,12 @@
                             &[ethabi::ParamType::Address],
                             log.topics[1usize].as_ref(),
                         )
-                        .map_err(|e| format!(
-                            "unable to decode param 'first' from topic of type 'address': {}",
-                            e
-                        ))?
+                        .map_err(|e| {
+                            format!(
+                                "unable to decode param 'first' from topic of type 'address': {}",
+                                e
+                            )
+                        })?
                         .pop()
                         .expect(INTERNAL_ERR)
                         .into_address()
@@ -173,10 +177,12 @@
                             &[ethabi::ParamType::Uint(256usize)],
                             log.topics[2usize].as_ref(),
                         )
-                        .map_err(|e| format!(
-                            "unable to decode param 'third' from topic of type 'uint256': {}",
-                            e
-                        ))?
+                        .map_err(|e| {
+                            format!(
+                                "unable to decode param 'third' from topic of type 'uint256': {}",
+                                e
+                            )
+                        })?
                         .pop()
                         .expect(INTERNAL_ERR)
                         .into_uint()
@@ -273,10 +279,12 @@
                             &[ethabi::ParamType::Address],
                             log.topics[1usize].as_ref(),
                         )
-                        .map_err(|e| format!(
-                            "unable to decode param 'first' from topic of type 'address': {}",
-                            e
-                        ))?
+                        .map_err(|e| {
+                            format!(
+                                "unable to decode param 'first' from topic of type 'address': {}",
+                                e
+                            )
+                        })?
                         .pop()
                         .expect(INTERNAL_ERR)
                         .into_address()
@@ -287,10 +295,12 @@
                             &[ethabi::ParamType::Address],
                             log.topics[2usize].as_ref(),
                         )
-                        .map_err(|e| format!(
-                            "unable to decode param 'fourth' from topic of type 'address': {}",
-                            e
-                        ))?
+                        .map_err(|e| {
+                            format!(
+                                "unable to decode param 'fourth' from topic of type 'address': {}",
+                                e
+                            )
+                        })?
                         .pop()
                         .expect(INTERNAL_ERR)
                         .into_address()
@@ -378,10 +388,12 @@
                             &[ethabi::ParamType::Address],
                             log.topics[1usize].as_ref(),
                         )
-                        .map_err(|e| format!(
-                            "unable to decode param 'first' from topic of type 'address': {}",
-                            e
-                        ))?
+                        .map_err(|e| {
+                            format!(
+                                "unable to decode param 'first' from topic of type 'address': {}",
+                                e
+                            )
+                        })?
                         .pop()
                         .expect(INTERNAL_ERR)
                         .into_address()
@@ -458,10 +470,12 @@
                             &[ethabi::ParamType::String],
                             log.topics[1usize].as_ref(),
                         )
-                        .map_err(|e| format!(
-                            "unable to decode param 'second' from topic of type 'string': {}",
-                            e
-                        ))?
+                        .map_err(|e| {
+                            format!(
+                                "unable to decode param 'second' from topic of type 'string': {}",
+                                e
+                            )
+                        })?
                         .pop()
                         .expect(INTERNAL_ERR)
                         .into_string()
@@ -536,10 +550,12 @@
                             &[ethabi::ParamType::Uint(256usize)],
                             log.topics[1usize].as_ref(),
                         )
-                        .map_err(|e| format!(
-                            "unable to decode param 'third' from topic of type 'uint256': {}",
-                            e
-                        ))?
+                        .map_err(|e| {
+                            format!(
+                                "unable to decode param 'third' from topic of type 'uint256': {}",
+                                e
+                            )
+                        })?
                         .pop()
                         .expect(INTERNAL_ERR)
                         .into_uint()

--- a/abigen-tests/src/abi/tests.rs
+++ b/abigen-tests/src/abi/tests.rs
@@ -96,6 +96,17 @@
                 }
             }
         }
+        impl substreams_ethereum::Event for EventAddressIdxString {
+            const NAME: &'static str = "EventAddressIdxString";
+            fn match_log(log: &substreams_ethereum::pb::eth::v1::Log) -> bool {
+                Self::match_log(log)
+            }
+            fn decode(
+                log: &substreams_ethereum::pb::eth::v1::Log,
+            ) -> Result<Self, String> {
+                Self::decode(log)
+            }
+        }
         #[derive(Debug, Clone, PartialEq)]
         pub struct EventAddressIdxStringUint256IdxBytes {
             pub first: Vec<u8>,
@@ -209,6 +220,17 @@
                         )
                     }
                 }
+            }
+        }
+        impl substreams_ethereum::Event for EventAddressIdxStringUint256IdxBytes {
+            const NAME: &'static str = "EventAddressIdxStringUint256IdxBytes";
+            fn match_log(log: &substreams_ethereum::pb::eth::v1::Log) -> bool {
+                Self::match_log(log)
+            }
+            fn decode(
+                log: &substreams_ethereum::pb::eth::v1::Log,
+            ) -> Result<Self, String> {
+                Self::decode(log)
             }
         }
         #[derive(Debug, Clone, PartialEq)]
@@ -331,6 +353,17 @@
                 }
             }
         }
+        impl substreams_ethereum::Event for EventAddressIdxUint256Uint256AddressIdx {
+            const NAME: &'static str = "EventAddressIdxUint256Uint256AddressIdx";
+            fn match_log(log: &substreams_ethereum::pb::eth::v1::Log) -> bool {
+                Self::match_log(log)
+            }
+            fn decode(
+                log: &substreams_ethereum::pb::eth::v1::Log,
+            ) -> Result<Self, String> {
+                Self::decode(log)
+            }
+        }
         #[derive(Debug, Clone, PartialEq)]
         pub struct EventWithOverloads1 {
             pub first: Vec<u8>,
@@ -413,6 +446,17 @@
                 }
             }
         }
+        impl substreams_ethereum::Event for EventWithOverloads1 {
+            const NAME: &'static str = "EventWithOverloads1";
+            fn match_log(log: &substreams_ethereum::pb::eth::v1::Log) -> bool {
+                Self::match_log(log)
+            }
+            fn decode(
+                log: &substreams_ethereum::pb::eth::v1::Log,
+            ) -> Result<Self, String> {
+                Self::decode(log)
+            }
+        }
         #[derive(Debug, Clone, PartialEq)]
         pub struct EventWithOverloads2 {
             pub second: String,
@@ -493,6 +537,17 @@
                 }
             }
         }
+        impl substreams_ethereum::Event for EventWithOverloads2 {
+            const NAME: &'static str = "EventWithOverloads2";
+            fn match_log(log: &substreams_ethereum::pb::eth::v1::Log) -> bool {
+                Self::match_log(log)
+            }
+            fn decode(
+                log: &substreams_ethereum::pb::eth::v1::Log,
+            ) -> Result<Self, String> {
+                Self::decode(log)
+            }
+        }
         #[derive(Debug, Clone, PartialEq)]
         pub struct EventWithOverloads3 {
             pub third: ethabi::Uint,
@@ -571,6 +626,17 @@
                         )
                     }
                 }
+            }
+        }
+        impl substreams_ethereum::Event for EventWithOverloads3 {
+            const NAME: &'static str = "EventWithOverloads3";
+            fn match_log(log: &substreams_ethereum::pb::eth::v1::Log) -> bool {
+                Self::match_log(log)
+            }
+            fn decode(
+                log: &substreams_ethereum::pb::eth::v1::Log,
+            ) -> Result<Self, String> {
+                Self::decode(log)
             }
         }
     }

--- a/abigen-tests/src/abi/tests.rs
+++ b/abigen-tests/src/abi/tests.rs
@@ -85,16 +85,6 @@
                         .expect(INTERNAL_ERR),
                 })
             }
-            pub fn must_decode(log: &substreams_ethereum::pb::eth::v1::Log) -> Self {
-                match Self::decode(log) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        panic!(
-                            "Unable to decode logs.EventAddressIdxString event: {:#}", e
-                        )
-                    }
-                }
-            }
         }
         impl substreams_ethereum::Event for EventAddressIdxString {
             const NAME: &'static str = "EventAddressIdxString";
@@ -209,17 +199,6 @@
                         .into_string()
                         .expect(INTERNAL_ERR),
                 })
-            }
-            pub fn must_decode(log: &substreams_ethereum::pb::eth::v1::Log) -> Self {
-                match Self::decode(log) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        panic!(
-                            "Unable to decode logs.EventAddressIdxStringUint256IdxBytes event: {:#}",
-                            e
-                        )
-                    }
-                }
             }
         }
         impl substreams_ethereum::Event for EventAddressIdxStringUint256IdxBytes {
@@ -341,17 +320,6 @@
                         .expect(INTERNAL_ERR),
                 })
             }
-            pub fn must_decode(log: &substreams_ethereum::pb::eth::v1::Log) -> Self {
-                match Self::decode(log) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        panic!(
-                            "Unable to decode logs.EventAddressIdxUint256Uint256AddressIdx event: {:#}",
-                            e
-                        )
-                    }
-                }
-            }
         }
         impl substreams_ethereum::Event for EventAddressIdxUint256Uint256AddressIdx {
             const NAME: &'static str = "EventAddressIdxUint256Uint256AddressIdx";
@@ -435,16 +403,6 @@
                         .to_vec(),
                 })
             }
-            pub fn must_decode(log: &substreams_ethereum::pb::eth::v1::Log) -> Self {
-                match Self::decode(log) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        panic!(
-                            "Unable to decode logs.EventWithOverloads1 event: {:#}", e
-                        )
-                    }
-                }
-            }
         }
         impl substreams_ethereum::Event for EventWithOverloads1 {
             const NAME: &'static str = "EventWithOverloads1";
@@ -526,16 +484,6 @@
                         .expect(INTERNAL_ERR),
                 })
             }
-            pub fn must_decode(log: &substreams_ethereum::pb::eth::v1::Log) -> Self {
-                match Self::decode(log) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        panic!(
-                            "Unable to decode logs.EventWithOverloads2 event: {:#}", e
-                        )
-                    }
-                }
-            }
         }
         impl substreams_ethereum::Event for EventWithOverloads2 {
             const NAME: &'static str = "EventWithOverloads2";
@@ -616,16 +564,6 @@
                         .into_uint()
                         .expect(INTERNAL_ERR),
                 })
-            }
-            pub fn must_decode(log: &substreams_ethereum::pb::eth::v1::Log) -> Self {
-                match Self::decode(log) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        panic!(
-                            "Unable to decode logs.EventWithOverloads3 event: {:#}", e
-                        )
-                    }
-                }
             }
         }
         impl substreams_ethereum::Event for EventWithOverloads3 {

--- a/abigen/Cargo.toml
+++ b/abigen/Cargo.toml
@@ -20,6 +20,7 @@ syn = { version = "1.0.95", default-features = false, features = ["derive", "par
 quote = "1.0.2"
 proc-macro2 = "1.0.7"
 prettyplease = "0.1"
+substreams-ethereum-core = { version = "0.1.4", path = "../core" }
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"

--- a/abigen/src/event.rs
+++ b/abigen/src/event.rs
@@ -137,6 +137,7 @@ impl<'a> From<(&'a String, &'a ethabi::Event)> for Event {
 impl Event {
     /// Generates rust interface for contract's event.
     pub fn generate_event(&self) -> TokenStream {
+        let name = &self.name;
         let topic_count = &self.topic_count;
         let topic_hash_bytes: Vec<_> = self
             .topic_hash
@@ -210,6 +211,16 @@ impl Event {
                         Ok(v) => v,
                         Err(e) => panic!(#must_decode_error_msg, e),
                     }
+                }
+            }
+
+            impl substreams_ethereum::Event for #camel_name {
+                const NAME: &'static str = #name;
+                fn match_log(log: &substreams_ethereum::pb::eth::v1::Log) -> bool {
+                    Self::match_log(log)
+                }
+                fn decode(log: &substreams_ethereum::pb::eth::v1::Log) -> Result<Self, String> {
+                    Self::decode(log)
                 }
             }
         }
@@ -293,6 +304,15 @@ mod tests {
                             Ok(v) => v,
                             Err(e) => panic!("Unable to decode logs.Hello event: {:#}", e),
                         }
+                    }
+                }
+                impl substreams_ethereum::Event for Hello {
+                    const NAME: &'static str = "hello";
+                    fn match_log(log: &substreams_ethereum::pb::eth::v1::Log) -> bool {
+                        Self::match_log(log)
+                    }
+                    fn decode(log: &substreams_ethereum::pb::eth::v1::Log) -> Result<Self, String> {
+                        Self::decode(log)
                     }
                 }
             },
@@ -390,6 +410,15 @@ mod tests {
                             Ok(v) => v,
                             Err(e) => panic!("Unable to decode logs.One event: {:#}", e),
                         }
+                    }
+                }
+                impl substreams_ethereum::Event for One {
+                    const NAME: &'static str = "one";
+                    fn match_log(log: &substreams_ethereum::pb::eth::v1::Log) -> bool {
+                        Self::match_log(log)
+                    }
+                    fn decode(log: &substreams_ethereum::pb::eth::v1::Log) -> Result<Self, String> {
+                        Self::decode(log)
                     }
                 }
             },
@@ -526,6 +555,15 @@ mod tests {
                         }
                     }
                 }
+                impl substreams_ethereum::Event for Transfer {
+                    const NAME: &'static str = "Transfer";
+                    fn match_log(log: &substreams_ethereum::pb::eth::v1::Log) -> bool {
+                        Self::match_log(log)
+                    }
+                    fn decode(log: &substreams_ethereum::pb::eth::v1::Log) -> Result<Self, String> {
+                        Self::decode(log)
+                    }
+                }
             },
         );
     }
@@ -660,6 +698,15 @@ mod tests {
                             Ok(v) => v,
                             Err(e) => panic!("Unable to decode logs.Transfer event: {:#}", e),
                         }
+                    }
+                }
+                impl substreams_ethereum::Event for Transfer {
+                    const NAME: &'static str = "Transfer";
+                    fn match_log(log: &substreams_ethereum::pb::eth::v1::Log) -> bool {
+                        Self::match_log(log)
+                    }
+                    fn decode(log: &substreams_ethereum::pb::eth::v1::Log) -> Result<Self, String> {
+                        Self::decode(log)
                     }
                 }
             },

--- a/abigen/src/event.rs
+++ b/abigen/src/event.rs
@@ -154,11 +154,6 @@ impl Event {
         decode_fields.extend(self.decode_indexed_fields.iter());
         decode_fields.extend(self.decode_unindexed_fields.iter());
 
-        let must_decode_error_msg = format!(
-            "Unable to decode logs.{} event: {{:#}}",
-            self.name.to_upper_camel_case()
-        );
-
         let min_data_size = &self.min_data_size;
         let log_match_data = match &self.fixed_data_size {
             Some(fixed_data_size) => {
@@ -204,13 +199,6 @@ impl Event {
                     Ok(Self {
                         #(#decode_fields),*
                     })
-                }
-
-                pub fn must_decode(log: &substreams_ethereum::pb::eth::v1::Log) -> Self {
-                    match Self::decode(log) {
-                        Ok(v) => v,
-                        Err(e) => panic!(#must_decode_error_msg, e),
-                    }
                 }
             }
 
@@ -298,12 +286,6 @@ mod tests {
                         log: &substreams_ethereum::pb::eth::v1::Log
                     ) -> Result<Self, String> {
                         Ok(Self {})
-                    }
-                    pub fn must_decode(log: &substreams_ethereum::pb::eth::v1::Log) -> Self {
-                        match Self::decode(log) {
-                            Ok(v) => v,
-                            Err(e) => panic!("Unable to decode logs.Hello event: {:#}", e),
-                        }
                     }
                 }
                 impl substreams_ethereum::Event for Hello {
@@ -404,12 +386,6 @@ mod tests {
                                 .as_bytes()
                                 .to_vec()
                         })
-                    }
-                    pub fn must_decode(log: &substreams_ethereum::pb::eth::v1::Log) -> Self {
-                        match Self::decode(log) {
-                            Ok(v) => v,
-                            Err(e) => panic!("Unable to decode logs.One event: {:#}", e),
-                        }
                     }
                 }
                 impl substreams_ethereum::Event for One {
@@ -547,12 +523,6 @@ mod tests {
                                 .into_uint()
                                 .expect(INTERNAL_ERR)
                         })
-                    }
-                    pub fn must_decode(log: &substreams_ethereum::pb::eth::v1::Log) -> Self {
-                        match Self::decode(log) {
-                            Ok(v) => v,
-                            Err(e) => panic!("Unable to decode logs.Transfer event: {:#}", e),
-                        }
                     }
                 }
                 impl substreams_ethereum::Event for Transfer {
@@ -692,12 +662,6 @@ mod tests {
                                 .into_uint()
                                 .expect(INTERNAL_ERR)
                         })
-                    }
-                    pub fn must_decode(log: &substreams_ethereum::pb::eth::v1::Log) -> Self {
-                        match Self::decode(log) {
-                            Ok(v) => v,
-                            Err(e) => panic!("Unable to decode logs.Transfer event: {:#}", e),
-                        }
                     }
                 }
                 impl substreams_ethereum::Event for Transfer {

--- a/core/src/block_view.rs
+++ b/core/src/block_view.rs
@@ -1,0 +1,173 @@
+use crate::pb::eth::v1 as pb;
+
+impl pb::Block {
+    /// Iterates over succesful transactions.
+    pub fn transactions(&self) -> impl Iterator<Item = TransactionView> {
+        self.transaction_traces
+            .iter()
+            .filter(|tx| tx.status == 1)
+            .map(|transaction| TransactionView {
+                block: self,
+                transaction,
+            })
+    }
+
+    /// Iterates over transaction receipts of succesful transactions.
+    pub fn receipts(&self) -> impl Iterator<Item = ReceiptView> {
+        self.transactions().map(|transaction| ReceiptView {
+            transaction,
+            receipt: transaction.transaction.receipt.as_ref().unwrap(),
+        })
+    }
+
+    /// Iterates over logs in receipts of succesful transactions.
+    pub fn logs(&self) -> impl Iterator<Item = LogView> {
+        self.receipts().map(|receipt| receipt.logs()).flatten()
+    }
+}
+
+#[derive(Copy, Clone)]
+pub struct TransactionView<'a> {
+    pub block: &'a pb::Block,
+    pub transaction: &'a pb::TransactionTrace,
+}
+
+#[derive(Copy, Clone)]
+pub struct ReceiptView<'a> {
+    pub transaction: TransactionView<'a>,
+    pub receipt: &'a pb::TransactionReceipt,
+}
+
+#[derive(Copy, Clone)]
+pub struct LogView<'a> {
+    pub receipt: ReceiptView<'a>,
+    pub log: &'a pb::Log,
+}
+
+impl<'a> TransactionView<'a> {
+    pub fn to(self) -> &'a [u8] {
+        &self.transaction.to
+    }
+
+    pub fn nonce(self) -> u64 {
+        self.transaction.nonce
+    }
+
+    pub fn gas_price(self) -> &'a pb::BigInt {
+        self.transaction.gas_price.as_ref().unwrap()
+    }
+
+    pub fn gas_limit(self) -> u64 {
+        self.transaction.gas_limit
+    }
+    pub fn value(self) -> &'a pb::BigInt {
+        self.transaction.value.as_ref().unwrap()
+    }
+    pub fn input(self) -> &'a [u8] {
+        &self.transaction.input
+    }
+    pub fn v(self) -> &'a [u8] {
+        &self.transaction.v
+    }
+    pub fn r(self) -> &'a [u8] {
+        &self.transaction.r
+    }
+    pub fn s(self) -> &'a [u8] {
+        &self.transaction.s
+    }
+    pub fn gas_used(self) -> u64 {
+        self.transaction.gas_used
+    }
+    pub fn r#type(self) -> i32 {
+        self.transaction.r#type
+    }
+    pub fn access_list(self) -> &'a Vec<pb::AccessTuple> {
+        &self.transaction.access_list
+    }
+    pub fn max_fee_per_gas(self) -> Option<&'a pb::BigInt> {
+        self.transaction.max_fee_per_gas.as_ref()
+    }
+    pub fn max_priority_fee_per_gas(self) -> Option<&'a pb::BigInt> {
+        self.transaction.max_priority_fee_per_gas.as_ref()
+    }
+    pub fn index(self) -> u32 {
+        self.transaction.index
+    }
+    pub fn hash(self) -> &'a [u8] {
+        &self.transaction.hash
+    }
+    pub fn from(self) -> &'a [u8] {
+        &self.transaction.from
+    }
+    pub fn return_data(self) -> &'a [u8] {
+        &self.transaction.return_data
+    }
+    pub fn public_key(self) -> &'a [u8] {
+        &self.transaction.public_key
+    }
+    pub fn begin_ordinal(self) -> u64 {
+        self.transaction.begin_ordinal
+    }
+    pub fn end_ordinal(self) -> u64 {
+        self.transaction.end_ordinal
+    }
+    pub fn status(self) -> i32 {
+        self.transaction.status
+    }
+    pub fn receipt(self) -> ReceiptView<'a> {
+        ReceiptView {
+            transaction: self,
+            receipt: &self.transaction.receipt.as_ref().unwrap(),
+        }
+    }
+
+    // TODO: Call view, filtering out failed calls
+    // pub fn calls: Vec<CallView> { }
+}
+
+impl<'a> ReceiptView<'a> {
+    pub fn state_root(self) -> &'a [u8] {
+        &self.receipt.state_root
+    }
+
+    pub fn cumulative_gas_used(self) -> u64 {
+        self.receipt.cumulative_gas_used
+    }
+
+    pub fn logs_bloom(self) -> &'a [u8] {
+        &self.receipt.logs_bloom
+    }
+
+    pub fn logs(self) -> impl Iterator<Item = LogView<'a>> {
+        self.receipt
+            .logs
+            .iter()
+            .map(move |log| LogView { receipt: self, log })
+    }
+}
+
+impl<'a> LogView<'a> {
+    pub fn address(self) -> &'a [u8] {
+        &self.log.address
+    }
+
+    pub fn topics(self) -> &'a Vec<Vec<u8>> {
+        &self.log.topics
+    }
+
+    pub fn data(self) -> &'a [u8] {
+        &self.log.data
+    }
+
+    pub fn index(self) -> u32 {
+        self.log.index
+    }
+
+    pub fn block_index(self) -> u32 {
+        self.log.index
+    }
+
+    pub fn ordinal(self) -> u64 {
+        self.log.ordinal
+    }
+}

--- a/core/src/block_view.rs
+++ b/core/src/block_view.rs
@@ -2,21 +2,15 @@ use crate::{pb::eth::v1 as pb, Event};
 
 impl pb::Block {
     /// Iterates over succesful transactions.
-    pub fn transactions(&self) -> impl Iterator<Item = TransactionView> {
-        self.transaction_traces
-            .iter()
-            .filter(|tx| tx.status == 1)
-            .map(|transaction| TransactionView {
-                block: self,
-                transaction,
-            })
+    pub fn transactions(&self) -> impl Iterator<Item = &pb::TransactionTrace> {
+        self.transaction_traces.iter().filter(|tx| tx.status == 1)
     }
 
     /// Iterates over transaction receipts of succesful transactions.
     pub fn receipts(&self) -> impl Iterator<Item = ReceiptView> {
         self.transactions().map(|transaction| ReceiptView {
             transaction,
-            receipt: transaction.transaction.receipt.as_ref().unwrap(),
+            receipt: transaction.receipt.as_ref().unwrap(),
         })
     }
 
@@ -55,14 +49,8 @@ impl pb::Block {
 }
 
 #[derive(Copy, Clone)]
-pub struct TransactionView<'a> {
-    pub block: &'a pb::Block,
-    pub transaction: &'a pb::TransactionTrace,
-}
-
-#[derive(Copy, Clone)]
 pub struct ReceiptView<'a> {
-    pub transaction: TransactionView<'a>,
+    pub transaction: &'a pb::TransactionTrace,
     pub receipt: &'a pb::TransactionReceipt,
 }
 
@@ -72,80 +60,11 @@ pub struct LogView<'a> {
     pub log: &'a pb::Log,
 }
 
-impl<'a> TransactionView<'a> {
-    pub fn to(self) -> &'a [u8] {
-        &self.transaction.to
-    }
-
-    pub fn nonce(self) -> u64 {
-        self.transaction.nonce
-    }
-
-    pub fn gas_price(self) -> &'a pb::BigInt {
-        self.transaction.gas_price.as_ref().unwrap()
-    }
-
-    pub fn gas_limit(self) -> u64 {
-        self.transaction.gas_limit
-    }
-    pub fn value(self) -> &'a pb::BigInt {
-        self.transaction.value.as_ref().unwrap()
-    }
-    pub fn input(self) -> &'a [u8] {
-        &self.transaction.input
-    }
-    pub fn v(self) -> &'a [u8] {
-        &self.transaction.v
-    }
-    pub fn r(self) -> &'a [u8] {
-        &self.transaction.r
-    }
-    pub fn s(self) -> &'a [u8] {
-        &self.transaction.s
-    }
-    pub fn gas_used(self) -> u64 {
-        self.transaction.gas_used
-    }
-    pub fn r#type(self) -> i32 {
-        self.transaction.r#type
-    }
-    pub fn access_list(self) -> &'a Vec<pb::AccessTuple> {
-        &self.transaction.access_list
-    }
-    pub fn max_fee_per_gas(self) -> Option<&'a pb::BigInt> {
-        self.transaction.max_fee_per_gas.as_ref()
-    }
-    pub fn max_priority_fee_per_gas(self) -> Option<&'a pb::BigInt> {
-        self.transaction.max_priority_fee_per_gas.as_ref()
-    }
-    pub fn index(self) -> u32 {
-        self.transaction.index
-    }
-    pub fn hash(self) -> &'a [u8] {
-        &self.transaction.hash
-    }
-    pub fn from(self) -> &'a [u8] {
-        &self.transaction.from
-    }
-    pub fn return_data(self) -> &'a [u8] {
-        &self.transaction.return_data
-    }
-    pub fn public_key(self) -> &'a [u8] {
-        &self.transaction.public_key
-    }
-    pub fn begin_ordinal(self) -> u64 {
-        self.transaction.begin_ordinal
-    }
-    pub fn end_ordinal(self) -> u64 {
-        self.transaction.end_ordinal
-    }
-    pub fn status(self) -> i32 {
-        self.transaction.status
-    }
-    pub fn receipt(self) -> ReceiptView<'a> {
+impl pb::TransactionTrace {
+    pub fn receipt(&self) -> ReceiptView {
         ReceiptView {
             transaction: self,
-            receipt: &self.transaction.receipt.as_ref().unwrap(),
+            receipt: &self.receipt.as_ref().unwrap(),
         }
     }
 

--- a/core/src/event.rs
+++ b/core/src/event.rs
@@ -1,0 +1,37 @@
+use crate::pb::eth::v1::Log;
+
+pub trait Event: Sized {
+    const NAME: &'static str;
+
+    fn match_log(log: &Log) -> bool;
+    fn decode(log: &Log) -> Result<Self, String>;
+
+    /// Attempts to match and decode the log.
+    /// If `Self::match_log(log)` is `false`, returns `None`.
+    /// If it matches, but decoding fails, logs the decoding error and returns `None`.
+    fn match_and_decode(log: impl AsRef<Log>) -> Option<Self> {
+        let log = log.as_ref();
+        if !Self::match_log(log) {
+            return None;
+        }
+
+        match Self::decode(&log) {
+            Ok(event) => Some(event),
+            Err(err) => {
+                substreams::log::info!(
+                    "Log for event `{}` at index {} matched but failed to decode with error: {}",
+                    Self::NAME,
+                    log.block_index,
+                    err
+                );
+                None
+            }
+        }
+    }
+}
+
+impl AsRef<Log> for Log {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -17,3 +17,10 @@ pub const NULL_ADDRESS: [u8; 20] = [
     0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
     0u8,
 ];
+
+pub trait Event: Sized {
+    const NAME: &'static str;
+
+    fn match_log(log: &crate::pb::eth::v1::Log) -> bool;
+    fn decode(log: &crate::pb::eth::v1::Log) -> Result<Self, String>;
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,6 +1,9 @@
 pub mod pb;
 pub mod rpc;
 
+/// Helpers to deal with block sources.
+pub mod block_view;
+
 mod abi;
 mod externs;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -4,7 +4,10 @@ pub mod rpc;
 /// Helpers to deal with block sources.
 pub mod block_view;
 
+pub use event::Event;
+
 mod abi;
+mod event;
 mod externs;
 
 /// Represents the null address static array in bytes (20 bytes) which in hex is equivalent
@@ -17,10 +20,3 @@ pub const NULL_ADDRESS: [u8; 20] = [
     0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
     0u8,
 ];
-
-pub trait Event: Sized {
-    const NAME: &'static str;
-
-    fn match_log(log: &crate::pb::eth::v1::Log) -> bool;
-    fn decode(log: &crate::pb::eth::v1::Log) -> Result<Self, String>;
-}

--- a/substreams-ethereum/src/lib.rs
+++ b/substreams-ethereum/src/lib.rs
@@ -1,4 +1,4 @@
-pub use substreams_ethereum_core::{pb, rpc, NULL_ADDRESS};
+pub use substreams_ethereum_core::{pb, rpc, Event, NULL_ADDRESS};
 pub use substreams_ethereum_derive::EthabiContract;
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]

--- a/substreams-ethereum/src/lib.rs
+++ b/substreams-ethereum/src/lib.rs
@@ -59,11 +59,6 @@ pub use substreams_ethereum_abigen::build::Abigen;
 ///                // ...
 ///                # todo!()
 ///             }
-///
-///             pub fn must_decode(log: &substreams_ethereum::pb::eth::v1::Log) -> Transfer {
-///                // ...
-///                # todo!()
-///             }
 ///         }
 ///
 ///         // ... Other events ...


### PR DESCRIPTION
This adds a `block_view` module, which adds helper methods to `Block` to iterate over transactions, receipts, logs and events. These views hold a reference to the context, so for example the receipt view holds both the receipt itself and a 'backreference' to the respective transaction. Depends on #4.

This ultimately allows writing a handler as easily as:
```rust
#[substreams::handlers::map]
fn map_pairs(block: eth::Block) -> Result<uniswap::Pairs, Error> {
    let pairs = block
        .events::<abi::factory::events::PairCreated>(&[&FACTORY])
        .map(|(event, log)| {
            log::info!("Pair created: 0x{}", Hex(&event.pair));

            uniswap::Pair {
                address: event.pair,
                token0: event.token0,
                token1: event.token1,
                ordinal: log.ordinal(),
            }
        })
        .collect();
    Ok(uniswap::Pairs { pairs })
}
```