### PR TITLE
WIP Added first working version of ABI generation for functions

### DIFF
--- a/abigen-tests/Cargo.toml
+++ b/abigen-tests/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "substreams-abigen-tests"
+name = "substreams-ethereum-abigen-tests"
 version = "0.2.0"
 edition = "2021"
 description = "Tests package meant to test the generated code of the abigen"
@@ -8,6 +8,7 @@ rust-version = "1.60"
 
 [dependencies]
 ethabi = "17.0"
+num-bigint = "0.4.3"
 prost = { version = "^0.11.0" }
 prost-types = "^0.11.0"
 substreams = { version = "~0.0.19" }

--- a/abigen-tests/abi/tests.json
+++ b/abigen-tests/abi/tests.json
@@ -120,6 +120,63 @@
     "type": "event"
   },
 	{
+		"name": "funReturnsString",
+		"inputs": [],
+		"outputs": [
+			{
+				"internalType": "string",
+				"name": "first",
+				"type": "string"
+			}
+		],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"name": "funReturnsString",
+		"inputs": [],
+		"outputs": [
+			{
+				"internalType": "string",
+				"name": "first",
+				"type": "string"
+			}
+		],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"name": "funReturnsStringString",
+		"inputs": [],
+		"outputs": [
+			{
+				"internalType": "string",
+				"name": "first",
+				"type": "string"
+			},
+			{
+				"internalType": "string",
+				"name": "second",
+				"type": "string"
+			}
+		],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "string",
+				"name": "first",
+				"type": "string"
+			}
+		],
+		"name": "funString",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
 		"inputs": [
 			{
 				"internalType": "string",
@@ -135,6 +192,160 @@
 		"name": "funStringString",
 		"outputs": [],
 		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address[2]",
+				"name": "",
+				"type": "address[2]"
+			},
+			{
+				"internalType": "address[]",
+				"name": "",
+				"type": "address[]"
+			}
+		],
+		"name": "fixedArrayAddressArrayUint256ReturnsUint256String",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			},
+			{
+				"internalType": "string",
+				"name": "",
+				"type": "string"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "",
+				"type": "address"
+			},
+			{
+				"internalType": "bytes",
+				"name": "",
+				"type": "bytes"
+			},
+			{
+				"internalType": "bytes8",
+				"name": "",
+				"type": "bytes8"
+			},
+			{
+				"internalType": "bytes32",
+				"name": "",
+				"type": "bytes32"
+			},
+			{
+				"internalType": "int256",
+				"name": "",
+				"type": "int256"
+			},
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			},
+			{
+				"internalType": "bool",
+				"name": "",
+				"type": "bool"
+			},
+			{
+				"internalType": "string",
+				"name": "",
+				"type": "string"
+			},
+			{
+				"internalType": "address[2]",
+				"name": "",
+				"type": "address[2]"
+			},
+			{
+				"internalType": "address[]",
+				"name": "",
+				"type": "address[]"
+			}
+		],
+		"name": "funAll",
+		"outputs": [],
+		"stateMutability": "pure",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "int256",
+				"name": "",
+				"type": "int256"
+			}
+		],
+		"name": "funInt256",
+		"outputs": [],
+		"stateMutability": "pure",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "int32",
+				"name": "",
+				"type": "int32"
+			}
+		],
+		"name": "funInt32",
+		"outputs": [],
+		"stateMutability": "pure",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "int8",
+				"name": "",
+				"type": "int8"
+			}
+		],
+		"name": "funInt8",
+		"outputs": [],
+		"stateMutability": "pure",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "int8",
+				"name": "",
+				"type": "int8"
+			},
+			{
+				"internalType": "int32",
+				"name": "",
+				"type": "int32"
+			},
+			{
+				"internalType": "int64",
+				"name": "",
+				"type": "int64"
+			},
+			{
+				"internalType": "int256",
+				"name": "",
+				"type": "int256"
+			}
+		],
+		"name": "funInt8Int32Int64Int256",
+		"outputs": [],
+		"stateMutability": "pure",
 		"type": "function"
 	}
 ]

--- a/abigen-tests/src/abi/mod.rs
+++ b/abigen-tests/src/abi/mod.rs
@@ -1,2 +1,4 @@
 #[rustfmt::skip]
+#[allow(dead_code)]
+#[allow(unused_variables)]
 pub mod tests;

--- a/abigen-tests/src/lib.rs
+++ b/abigen-tests/src/lib.rs
@@ -5,7 +5,7 @@ mod tests {
     use crate::abi::tests;
     use ethabi::ethereum_types::U256;
     use pretty_assertions::assert_eq;
-    use substreams::hex;
+    use substreams::{hex, Hex};
     use substreams_ethereum::pb;
 
     #[test]
@@ -93,6 +93,326 @@ mod tests {
                 second: U256::from_str_radix("0x1000000000000000", 16).unwrap(),
                 third: U256::from_str_radix("0x2000000000000000000", 16).unwrap(),
                 fourth: hex!("cd91a50ad459b41fe065f7bbab866d5390e945fa").to_vec(),
+            }),
+        );
+    }
+
+    #[test]
+    fn it_decode_fun_input_string() {
+        use tests::functions::FunString as Function;
+
+        // Generated through Solidity in https://github.com/streamingfast/eth-go/blob/4d23b26dcf6bbe91fad82aabf162fe1f2622f4b4/tests/src/test/Codec.sol#L24-L25
+        let call = pb::eth::v2::Call {
+            input: hex!("b0d94419000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000047465737400000000000000000000000000000000000000000000000000000000").to_vec(),
+            ..Default::default()
+        };
+
+        assert_eq!(Function::match_call(&call), true);
+
+        let fun = Function::decode(&call);
+        assert_eq!(
+            fun,
+            Ok(Function {
+                first: "test".to_string(),
+            }),
+        );
+    }
+
+    #[test]
+    fn it_encode_fun_input_string() {
+        use tests::functions::FunString as Function;
+
+        let fun = Function {
+            first: "test".to_string(),
+        };
+
+        assert_eq!(fun.encode(), hex!("b0d94419000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000047465737400000000000000000000000000000000000000000000000000000000").to_vec());
+    }
+
+    #[test]
+    fn it_decode_fun_output_string() {
+        use tests::functions::FunReturnsString1 as Function;
+
+        // Generated through Solidity in https://github.com/streamingfast/eth-go/blob/4d23b26dcf6bbe91fad82aabf162fe1f2622f4b4/tests/src/test/Codec.sol#L24-L25
+        let call = pb::eth::v2::Call {
+            input: hex!("7a3719f0").to_vec(),
+            return_data: hex!("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000047465737400000000000000000000000000000000000000000000000000000000").to_vec(),
+            ..Default::default()
+        };
+
+        assert_eq!(Function::match_call(&call), true);
+
+        let output = Function::output_call(&call);
+        assert_eq!(output, Ok("test".to_string()));
+    }
+
+    #[test]
+    fn it_manual_decode_fun_output_string_string() {
+        let decoded = ethabi::decode(
+            &[ethabi::ParamType::String, ethabi::ParamType::String],
+            hex!("000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000005746573743100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000057465737432000000000000000000000000000000000000000000000000000000").as_ref(),
+        );
+
+        assert_eq!(
+            decoded.unwrap(),
+            vec![
+                ethabi::Token::String("test1".to_string()),
+                ethabi::Token::String("test2".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn it_decode_fun_output_string_string() {
+        use tests::functions::FunReturnsStringString as Function;
+
+        // Generated through Solidity in https://github.com/streamingfast/eth-go/blob/4d23b26dcf6bbe91fad82aabf162fe1f2622f4b4/tests/src/test/Codec.sol#L24-L25
+        let call = pb::eth::v2::Call {
+            input: hex!("85032f7c").to_vec(),
+            return_data: hex!("000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000005746573743100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000057465737432000000000000000000000000000000000000000000000000000000").to_vec(),
+            ..Default::default()
+        };
+
+        assert_eq!(Function::match_call(&call), true);
+
+        let output = Function::output_call(&call);
+        assert_eq!(output, Ok(("test1".to_string(), "test2".to_string())));
+    }
+
+    #[test]
+    fn it_encode_fun_input_fixed_array_address_array_uint256() {
+        use tests::functions::FixedArrayAddressArrayUint256ReturnsUint256String as Function;
+
+        let fun = Function {
+            param0: [
+                hex!("fffdb7377345371817f2b4dd490319755f5899ec").to_vec(),
+                hex!("fffdb7377345371817f2b4dd490319755f5899eb").to_vec(),
+            ],
+            param1: vec![
+                hex!("affdb7377345371817f2b4dd490319755f5899ec").to_vec(),
+                hex!("bffdb7377345371817f2b4dd490319755f5899ec").to_vec(),
+                hex!("cffdb7377345371817f2b4dd490319755f5899ec").to_vec(),
+            ],
+        };
+
+        assert_eq!(fun.encode(), hex!("74ac01d1000000000000000000000000fffdb7377345371817f2b4dd490319755f5899ec000000000000000000000000fffdb7377345371817f2b4dd490319755f5899eb00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000003000000000000000000000000affdb7377345371817f2b4dd490319755f5899ec000000000000000000000000bffdb7377345371817f2b4dd490319755f5899ec000000000000000000000000cffdb7377345371817f2b4dd490319755f5899ec").to_vec());
+    }
+
+    #[test]
+    fn it_decode_fun_input_fixed_array_address_array_uint256() {
+        use tests::functions::FixedArrayAddressArrayUint256ReturnsUint256String as Function;
+
+        // Generated through Solidity in https://github.com/streamingfast/eth-go/blob/4d23b26dcf6bbe91fad82aabf162fe1f2622f4b4/tests/src/test/Codec.sol#L24-L25
+        let call = pb::eth::v2::Call {
+            input: hex!("74ac01d1000000000000000000000000fffdb7377345371817f2b4dd490319755f5899ec000000000000000000000000fffdb7377345371817f2b4dd490319755f5899eb00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000003000000000000000000000000affdb7377345371817f2b4dd490319755f5899ec000000000000000000000000bffdb7377345371817f2b4dd490319755f5899ec000000000000000000000000cffdb7377345371817f2b4dd490319755f5899ec").to_vec(),
+            ..Default::default()
+        };
+
+        assert_eq!(Function::match_call(&call), true);
+
+        let fun = Function::decode(&call);
+        assert_eq!(
+            fun,
+            Ok(Function {
+                param0: [
+                    hex!("fffdb7377345371817f2b4dd490319755f5899ec").to_vec(),
+                    hex!("fffdb7377345371817f2b4dd490319755f5899eb").to_vec()
+                ],
+                param1: vec![
+                    hex!("affdb7377345371817f2b4dd490319755f5899ec").to_vec(),
+                    hex!("bffdb7377345371817f2b4dd490319755f5899ec").to_vec(),
+                    hex!("cffdb7377345371817f2b4dd490319755f5899ec").to_vec(),
+                ],
+            }),
+        );
+    }
+
+    #[test]
+    fn it_manual_decode_fun_input_fixed_array_address_array_uint256() {
+        let decoded = ethabi::decode(
+            &[
+                ethabi::ParamType::FixedArray(
+                    Box::new(ethabi::ParamType::Address),
+                    2usize,
+                ),
+                ethabi::ParamType::Array(
+                    Box::new(ethabi::ParamType::Address),
+                ),
+            ],
+            hex!("000000000000000000000000fffdb7377345371817f2b4dd490319755f5899ec000000000000000000000000fffdb7377345371817f2b4dd490319755f5899eb00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000003000000000000000000000000affdb7377345371817f2b4dd490319755f5899ec000000000000000000000000bffdb7377345371817f2b4dd490319755f5899ec000000000000000000000000cffdb7377345371817f2b4dd490319755f5899ec").as_ref(),
+        );
+
+        assert_eq!(
+            decoded.unwrap(),
+            vec![
+                ethabi::Token::FixedArray(vec![
+                    ethabi::Token::Address(hex!("fffdb7377345371817f2b4dd490319755f5899ec").into()),
+                    ethabi::Token::Address(hex!("fffdb7377345371817f2b4dd490319755f5899eb").into())
+                ]),
+                ethabi::Token::Array(vec![
+                    ethabi::Token::Address(hex!("affdb7377345371817f2b4dd490319755f5899ec").into()),
+                    ethabi::Token::Address(hex!("bffdb7377345371817f2b4dd490319755f5899ec").into()),
+                    ethabi::Token::Address(hex!("cffdb7377345371817f2b4dd490319755f5899ec").into()),
+                ])
+            ]
+        );
+    }
+
+    #[test]
+    fn it_encode_fun_input_int8() {
+        use tests::functions::FunInt8 as Function;
+
+        let fun = Function {
+            param0: num_bigint::ToBigInt::to_bigint(&-127).unwrap(),
+        };
+
+        assert_eq!(
+            fun.encode(),
+            hex!("3036e687ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff81")
+                .to_vec()
+        );
+    }
+
+    #[test]
+    fn it_encode_fun_input_int32() {
+        use tests::functions::FunInt32 as Function;
+
+        let fun = Function {
+            param0: num_bigint::ToBigInt::to_bigint(&-898877731).unwrap(),
+        };
+
+        assert_eq!(
+            fun.encode(),
+            hex!("d78caab3ffffffffffffffffffffffffffffffffffffffffffffffffffffffffca6c36dd")
+                .to_vec()
+        );
+    }
+
+    #[test]
+    fn it_encode_fun_input_int256() {
+        use tests::functions::FunInt256 as Function;
+
+        let fun = Function {
+            param0: num_bigint::ToBigInt::to_bigint(&-9809887317731i64).unwrap(),
+        };
+
+        assert_eq!(
+            fun.encode(),
+            hex!("f70af73bfffffffffffffffffffffffffffffffffffffffffffffffffffff713f526b11d")
+                .to_vec()
+        );
+    }
+
+    #[test]
+    fn it_encode_fun_input_int8_int32_int64_int256() {
+        use tests::functions::FunInt8Int32Int64Int256 as Function;
+
+        let fun = Function {
+            param0: num_bigint::ToBigInt::to_bigint(&-127).unwrap(),
+            param1: num_bigint::ToBigInt::to_bigint(&-898877731).unwrap(),
+            param2: num_bigint::ToBigInt::to_bigint(&(-9809887317731 as i64)).unwrap(),
+            param3: num_bigint::ToBigInt::to_bigint(&(-223372036854775808 as i64)).unwrap(),
+        };
+
+        assert_eq!(
+            fun.encode(),
+            hex!("db617e8fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff81ffffffffffffffffffffffffffffffffffffffffffffffffffffffffca6c36ddfffffffffffffffffffffffffffffffffffffffffffffffffffff713f526b11dfffffffffffffffffffffffffffffffffffffffffffffffffce66c50e2840000")
+                .to_vec()
+        );
+    }
+
+    #[test]
+    fn it_decode_fun_input_int8_int32_int64_int256() {
+        use tests::functions::FunInt8Int32Int64Int256 as Function;
+
+        let call = pb::eth::v2::Call {
+            input: hex!("db617e8fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff81ffffffffffffffffffffffffffffffffffffffffffffffffffffffffca6c36ddfffffffffffffffffffffffffffffffffffffffffffffffffffff713f526b11dfffffffffffffffffffffffffffffffffffffffffffffffffce66c50e2840000").to_vec(),
+            ..Default::default()
+        };
+
+        assert_eq!(Function::match_call(&call), true);
+
+        let fun = Function::decode(&call);
+        assert_eq!(
+            fun,
+            Ok(Function {
+                param0: num_bigint::ToBigInt::to_bigint(&-127).unwrap(),
+                param1: num_bigint::ToBigInt::to_bigint(&-898877731).unwrap(),
+                param2: num_bigint::ToBigInt::to_bigint(&(-9809887317731 as i64)).unwrap(),
+                param3: num_bigint::ToBigInt::to_bigint(&(-223372036854775808 as i64)).unwrap(),
+            }),
+        );
+    }
+
+    #[test]
+    fn it_manual_encode_num_bitint_signed_bytes() {
+        let num = num_bigint::ToBigInt::to_bigint(&-9809887317731i64).unwrap();
+        let as_hex = num.to_signed_bytes_be();
+
+        let mut final_hex = [0xff as u8; 32];
+        as_hex
+            .into_iter()
+            .rev()
+            .enumerate()
+            .for_each(|(i, byte)| final_hex[31 - i] = byte);
+
+        assert_eq!(
+            Hex(final_hex).to_string(),
+            "fffffffffffffffffffffffffffffffffffffffffffffffffffff713f526b11d".to_string(),
+        );
+    }
+
+    #[test]
+    fn it_encode_fun_input_all() {
+        use tests::functions::FunAll as Function;
+
+        let fun = Function {
+            param0: hex!("FffDB7377345371817F2b4dD490319755F5899eC").to_vec(),
+            param1: hex!("b2").to_vec(),
+            param2: hex!("cf36ac4f97dc10d9"),
+            param3: hex!("cf36ac4f97dc10d91fc2cbb20d718e94a8cbfe0f82eaedc6a4aa38946fb797cd"),
+            param4: num_bigint::ToBigInt::to_bigint(&-9809887317731i64).unwrap(),
+            param5: 1827641804u64.into(),
+            param6: true,
+            param7: "test".to_string(),
+            param8: [
+                hex!("0000000000000000000000000000000000000000").to_vec(),
+                hex!("0000000000000000000000000000000000000000").to_vec(),
+            ],
+            param9: vec![],
+        };
+
+        assert_eq!(fun.encode(), hex!("1af93c31000000000000000000000000fffdb7377345371817f2b4dd490319755f5899ec0000000000000000000000000000000000000000000000000000000000000160cf36ac4f97dc10d9000000000000000000000000000000000000000000000000cf36ac4f97dc10d91fc2cbb20d718e94a8cbfe0f82eaedc6a4aa38946fb797cdfffffffffffffffffffffffffffffffffffffffffffffffffffff713f526b11d000000000000000000000000000000000000000000000000000000006cef99cc000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000001a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001e00000000000000000000000000000000000000000000000000000000000000001b200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000474657374000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000").to_vec());
+    }
+
+    #[test]
+    fn it_decode_fun_input_all() {
+        use tests::functions::FunAll as Function;
+
+        let call = pb::eth::v2::Call {
+            input: hex!("1af93c31000000000000000000000000fffdb7377345371817f2b4dd490319755f5899ec0000000000000000000000000000000000000000000000000000000000000160cf36ac4f97dc10d9000000000000000000000000000000000000000000000000cf36ac4f97dc10d91fc2cbb20d718e94a8cbfe0f82eaedc6a4aa38946fb797cdfffffffffffffffffffffffffffffffffffffffffffffffffffff713f526b11d000000000000000000000000000000000000000000000000000000006cef99cc000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000001a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001e00000000000000000000000000000000000000000000000000000000000000001b200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000474657374000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000").to_vec(),
+            ..Default::default()
+        };
+
+        assert_eq!(Function::match_call(&call), true);
+
+        let fun = Function::decode(&call);
+        assert_eq!(
+            fun,
+            Ok(Function {
+                param0: hex!("FffDB7377345371817F2b4dD490319755F5899eC").to_vec(),
+                param1: hex!("b2").to_vec(),
+                param2: hex!("cf36ac4f97dc10d9"),
+                param3: hex!("cf36ac4f97dc10d91fc2cbb20d718e94a8cbfe0f82eaedc6a4aa38946fb797cd"),
+                param4: num_bigint::ToBigInt::to_bigint(&-9809887317731i64).unwrap(),
+                param5: 1827641804u64.into(),
+                param6: true,
+                param7: "test".to_string(),
+                param8: [
+                    hex!("0000000000000000000000000000000000000000").to_vec(),
+                    hex!("0000000000000000000000000000000000000000").to_vec(),
+                ],
+                param9: vec![],
             }),
         );
     }

--- a/abigen/Cargo.toml
+++ b/abigen/Cargo.toml
@@ -24,3 +24,4 @@ substreams-ethereum-core = { version = "0.2.0", path = "../core" }
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"
+substreams = { version = "~0.0.19" }

--- a/abigen/src/contract.rs
+++ b/abigen/src/contract.rs
@@ -9,19 +9,19 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
-// use crate::{constructor::Constructor, event::Event, function::Function};
-use crate::event::Event;
+// use crate::{constructor::Constructor,};
+use crate::{event::Event, function::Function};
 
 /// Structure used to generate rust interface for solidity contract.
 pub struct Contract {
     // constructor: Option<Constructor>,
-    // functions: Vec<Function>,
+    functions: Vec<Function>,
     events: Vec<Event>,
 }
 
 impl<'a> From<&'a ethabi::Contract> for Contract {
     fn from(c: &'a ethabi::Contract) -> Self {
-        let events: Vec<_> = c
+        let mut events: Vec<_> = c
             .events
             .values()
             .flat_map(|events| {
@@ -37,9 +37,31 @@ impl<'a> From<&'a ethabi::Contract> for Contract {
             })
             .collect();
 
+        // Since some people will actually commit this code, we use a "stable" generation order
+        events.sort_by(|left: &Event, right: &Event| left.name.cmp(&right.name));
+
+        let mut functions: Vec<_> = c
+            .functions
+            .values()
+            .flat_map(|functions| {
+                let count = functions.len();
+
+                functions.iter().enumerate().map(move |(index, function)| {
+                    if count <= 1 {
+                        (&function.name, function).into()
+                    } else {
+                        (&format!("{}{}", function.name, index + 1), function).into()
+                    }
+                })
+            })
+            .collect();
+
+        // Since some people will actually commit this code, we use a "stable" generation order
+        functions.sort_by(|left: &Function, right: &Function| left.name.cmp(&right.name));
+
         Contract {
             // constructor: c.constructor.as_ref().map(Into::into),
-            // functions: c.functions().map(Into::into).collect(),
+            functions,
             events,
         }
     }
@@ -49,7 +71,7 @@ impl Contract {
     /// Generates rust interface for a contract.
     pub fn generate(&self) -> TokenStream {
         // let constructor = self.constructor.as_ref().map(Constructor::generate);
-        // let functions: Vec<_> = self.functions.iter().map(Function::generate).collect();
+        let functions: Vec<_> = self.functions.iter().map(Function::generate).collect();
         let events: Vec<_> = self
             .events
             .iter()
@@ -61,11 +83,13 @@ impl Contract {
 
             // #constructor
 
-            // Contract's functions.
-            // pub mod functions {
-            //     use super::INTERNAL_ERR;
-            //     #(#functions)*
-            // }
+            /// Contract's functions.
+            #[allow(dead_code)]
+            #[allow(unused_variables)]
+            pub mod functions {
+                use super::INTERNAL_ERR;
+                #(#functions)*
+            }
 
             /// Contract's events.
             #[allow(dead_code)]
@@ -102,6 +126,13 @@ mod test {
             c.generate(),
             quote! {
                 const INTERNAL_ERR: &'static str = "`ethabi_derive` internal error";
+
+                /// Contract's functions.
+                #[allow(dead_code)]
+                #[allow(unused_variables)]
+                pub mod functions {
+                    use super::INTERNAL_ERR;
+                }
 
                 /// Contract's events.
                 #[allow(dead_code)]

--- a/abigen/src/event.rs
+++ b/abigen/src/event.rs
@@ -9,7 +9,7 @@ use super::{from_token, rust_type, to_syntax_string};
 
 /// Structure used to generate contract's event interface.
 pub struct Event {
-    name: String,
+    pub(crate) name: String,
     topic_hash: [u8; 32],
     topic_count: usize,
     min_data_size: usize,
@@ -196,7 +196,6 @@ impl Event {
             }
 
             impl #camel_name {
-                // FIXME: We should generate the [u8; 32] directly and avoid hex_literal crate
                 const TOPIC_ID: [u8; 32] = [#(#topic_hash_bytes),*];
 
                 pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {

--- a/abigen/src/lib.rs
+++ b/abigen/src/lib.rs
@@ -15,11 +15,13 @@ pub mod build;
 // mod constructor;
 mod contract;
 mod event;
-// mod function;
+mod function;
 
 use anyhow::format_err;
 // use ethabi::{Contract, Error, Param, ParamType, Result};
-use ethabi::{Contract, Error, ParamType};
+use ethabi::{Contract, Error, Param, ParamType};
+use heck::ToSnakeCase;
+use proc_macro2::Span;
 // use heck::ToSnakeCase;
 use quote::quote;
 use std::{
@@ -114,7 +116,7 @@ fn rust_type(input: &ParamType) -> proc_macro2::TokenStream {
         }
         ParamType::FixedArray(ref kind, size) => {
             let t = rust_type(&*kind);
-            quote! { [#t, #size] }
+            quote! { [#t; #size] }
         }
         ParamType::Tuple(_) => {
             unimplemented!(
@@ -197,13 +199,78 @@ fn min_data_size(input: &ParamType) -> usize {
 
 // fn from_template_param(input: &ParamType, name: &syn::Ident) -> proc_macro2::TokenStream {
 //     match *input {
-//         ParamType::Array(_) => quote! { #name.into_iter().map(Into::into).collect::<Vec<_>>() },
-//         ParamType::FixedArray(_, _) => {
-//             quote! { (Box::new(#name.into()) as Box<[_]>).into_vec().into_iter().map(Into::into).collect::<Vec<_>>() }
+//         ParamType::Array(_) => {
+//             quote! { self.#name.into_iter().map(Into::into).collect::<Vec<_>>() }
 //         }
-//         _ => quote! {#name.into() },
+//         ParamType::FixedArray(_, _) => {
+//             quote! { (Box::new(self.#name.into()) as Box<[_]>).into_vec().into_iter().map(Into::into).collect::<Vec<_>>() }
+//         }
+//         ParamType::Address => quote! { ethabi::Address::from_slice(self.#name.as_ref() ) },
+//         _ => firehose_into_ethabi_type(input, quote! { self.#name }),
 //     }
 // }
+
+// fn firehose_into_ethabi_type(
+//     input: &ParamType,
+//     variable: proc_macro2::TokenStream,
+// ) -> proc_macro2::TokenStream {
+//     match *input {
+//         ParamType::Address => quote! { ethabi::Address::from_slice(#variable) },
+//         ParamType::String => quote! { #variable.clone() },
+//         _ => quote! {#variable.into() },
+//     }
+// }
+
+fn to_token(name: &proc_macro2::TokenStream, kind: &ParamType) -> proc_macro2::TokenStream {
+    match *kind {
+        ParamType::Address => {
+            quote! { ethabi::Token::Address(ethabi::Address::from_slice(&#name)) }
+        }
+        ParamType::Bytes => quote! { ethabi::Token::Bytes(#name.clone()) },
+        ParamType::FixedBytes(_) => quote! { ethabi::Token::FixedBytes(#name.as_ref().to_vec()) },
+        ParamType::Int(_) => {
+            quote! {
+                {
+                    let non_full_signed_bytes = #name.to_signed_bytes_be();
+                    let mut full_signed_bytes = [0xff as u8; 32];
+                    non_full_signed_bytes.into_iter().rev().enumerate().for_each(|(i, byte)| full_signed_bytes[31 - i] = byte);
+
+                    ethabi::Token::Int(ethabi::Int::from_big_endian(full_signed_bytes.as_ref()))
+                }
+            }
+        }
+        ParamType::Uint(_) => quote! { ethabi::Token::Uint(#name) },
+        ParamType::Bool => quote! { ethabi::Token::Bool(#name) },
+        ParamType::String => quote! { ethabi::Token::String(#name.clone()) },
+        ParamType::Array(ref kind) => {
+            let inner_name = quote! { inner };
+            let inner_loop = to_token(&inner_name, kind);
+            quote! {
+                // note the double {{
+                {
+                    let v = #name.iter().map(|#inner_name| #inner_loop).collect();
+                    ethabi::Token::Array(v)
+                }
+            }
+        }
+        ParamType::FixedArray(ref kind, _) => {
+            let inner_name = quote! { inner };
+            let inner_loop = to_token(&inner_name, kind);
+            quote! {
+                // note the double {{
+                {
+                    let v = #name.iter().map(|#inner_name| #inner_loop).collect();
+                    ethabi::Token::FixedArray(v)
+                }
+            }
+        }
+        ParamType::Tuple(_) => {
+            unimplemented!(
+                "Tuples are not supported. https://github.com/openethereum/ethabi/issues/175"
+            )
+        }
+    }
+}
 
 fn from_token(kind: &ParamType, token: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
     match *kind {
@@ -224,7 +291,16 @@ fn from_token(kind: &ParamType, token: &proc_macro2::TokenStream) -> proc_macro2
                 }
             }
         }
-        ParamType::Int(_) => quote! { #token.into_int().expect(INTERNAL_ERR) },
+        ParamType::Int(_) => {
+            quote! {
+                {
+                    let mut v = [0 as u8; 32];
+                    #token.into_int().expect(INTERNAL_ERR).to_big_endian(v.as_mut_slice());
+
+                    num_bigint::BigInt::from_signed_bytes_be(&v)
+                }
+            }
+        }
         ParamType::Uint(_) => quote! { #token.into_uint().expect(INTERNAL_ERR) },
         ParamType::Bool => quote! { #token.into_bool().expect(INTERNAL_ERR) },
         ParamType::String => quote! { #token.into_string().expect(INTERNAL_ERR) },
@@ -240,10 +316,10 @@ fn from_token(kind: &ParamType, token: &proc_macro2::TokenStream) -> proc_macro2
         ParamType::FixedArray(ref kind, size) => {
             let inner = quote! { inner };
             let inner_loop = from_token(kind, &inner);
-            let to_array = vec![quote! { iter.next() }; size];
+            let to_array = vec![quote! { iter.next().expect(INTERNAL_ERR) }; size];
             quote! {
                 {
-                    let iter = #token.to_array().expect(INTERNAL_ERR).into_iter()
+                    let mut iter = #token.into_fixed_array().expect(INTERNAL_ERR).into_iter()
                         .map(|#inner| #inner_loop);
                     [#(#to_array),*]
                 }
@@ -284,5 +360,65 @@ fn decode_topic(
 
             from_token(kind, &decode_topic)
         }
+    }
+}
+
+fn param_names(inputs: &[Param]) -> Vec<syn::Ident> {
+    inputs
+        .iter()
+        .enumerate()
+        .map(|(index, param)| {
+            if param.name.is_empty() {
+                syn::Ident::new(&format!("param{}", index), Span::call_site())
+            } else {
+                syn::Ident::new(&rust_variable(&param.name), Span::call_site())
+            }
+        })
+        .collect()
+}
+
+// fn get_template_names(kinds: &[proc_macro2::TokenStream]) -> Vec<syn::Ident> {
+//     kinds
+//         .iter()
+//         .enumerate()
+//         .map(|(index, _)| syn::Ident::new(&format!("T{}", index), Span::call_site()))
+//         .collect()
+// }
+
+fn get_output_kinds(outputs: &[Param]) -> proc_macro2::TokenStream {
+    match outputs.len() {
+        0 => quote! {()},
+        1 => {
+            let t = rust_type(&outputs[0].kind);
+            quote! { #t }
+        }
+        _ => {
+            let outs: Vec<_> = outputs.iter().map(|param| rust_type(&param.kind)).collect();
+            quote! { (#(#outs),*) }
+        }
+    }
+}
+
+/// Convert input into a rust variable name.
+///
+/// Avoid using keywords by escaping them.
+fn rust_variable(name: &str) -> String {
+    // avoid keyword parameters
+    match name {
+        "self" => "_self".to_string(),
+        other => other.to_snake_case(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn from_firehose_types_to_ethabi_token() {
+        use substreams::hex;
+
+        let firehose_address = hex!("0000000000000000000000000000000000000000").to_vec();
+
+        // Compilation is enough for those tests
+        ethabi::Token::Address(ethabi::Address::from_slice(firehose_address.as_ref()));
     }
 }

--- a/core/src/function.rs
+++ b/core/src/function.rs
@@ -1,0 +1,37 @@
+use crate::pb::eth::v2::Call;
+
+pub trait Function: Sized {
+    const NAME: &'static str;
+
+    fn match_call(log: &Call) -> bool;
+    fn decode(log: &Call) -> Result<Self, String>;
+
+    /// Attempts to match and decode the call.
+    /// If `Self::match_call(log)` is `false`, returns `None`.
+    /// If it matches, but decoding fails, logs the decoding error and returns `None`.
+    fn match_and_decode(call: impl AsRef<Call>) -> Option<Self> {
+        let call = call.as_ref();
+        if !Self::match_call(call) {
+            return None;
+        }
+
+        match Self::decode(&call) {
+            Ok(function) => Some(function),
+            Err(err) => {
+                substreams::log::info!(
+                    "Call for function `{}` at index {} matched but failed to decode with error: {}",
+                    Self::NAME,
+                    call.index,
+                    err
+                );
+                None
+            }
+        }
+    }
+}
+
+impl AsRef<Call> for Call {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -5,10 +5,12 @@ pub mod rpc;
 pub mod block_view;
 
 pub use event::Event;
+pub use function::Function;
 
 mod abi;
 mod event;
 mod externs;
+mod function;
 
 /// Represents the null address static array in bytes (20 bytes) which in hex is equivalent
 /// to:

--- a/substreams-ethereum/Cargo.toml
+++ b/substreams-ethereum/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["api-bindings", "external-ffi-bindings", "wasm"]
 rust-version = "1.60"
 
 [dependencies]
+substreams = "~0.0.20"
 substreams-ethereum-abigen = { version = "0.2.0", path = "../abigen" }
 substreams-ethereum-derive = { version = "0.2.0", path = "../derive" }
 substreams-ethereum-core = { version = "0.2.0", path = "../core" }

--- a/substreams-ethereum/src/lib.rs
+++ b/substreams-ethereum/src/lib.rs
@@ -1,4 +1,4 @@
-pub use substreams_ethereum_core::{pb, rpc, Event, NULL_ADDRESS};
+pub use substreams_ethereum_core::{pb, rpc, Event, Function, NULL_ADDRESS};
 pub use substreams_ethereum_derive::EthabiContract;
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]


### PR DESCRIPTION
It's possible to:
- Transform a `pb::eth::v2::Call` into ABI generated "function" (extracts decoded params of a call)
- Decode the output of `pb::eth::v2::Call` (extracts decoded output params of a call)
- Encode ABI generated "function" into Ethereum packed binary encoding
- Perform RPC call for any function defined in the ABI with automatic encoding of input and decoding of output

There is good chance the API will slightly change or be improved based on feedback.

