### PR TITLE
Fix and test FixedBytes size

### DIFF
--- a/abigen-tests/abi/tests.json
+++ b/abigen-tests/abi/tests.json
@@ -1,94 +1,119 @@
 [
-	{
-		"anonymous": false,
-		"inputs": [
-			{
-				"indexed": true,
-				"internalType": "address",
-				"name": "first",
-				"type": "address"
-			}
-		],
-		"name": "EventWithOverloads",
-		"type": "event"
-	},
-	{
-		"anonymous": false,
-		"inputs": [
-			{
-				"indexed": true,
-				"internalType": "string",
-				"name": "second",
-				"type": "string"
-			}
-		],
-		"name": "EventWithOverloads",
-		"type": "event"
-	},
-	{
-		"anonymous": false,
-		"inputs": [
-			{
-				"indexed": true,
-				"internalType": "uint256",
-				"name": "third",
-				"type": "uint256"
-			}
-		],
-		"name": "EventWithOverloads",
-		"type": "event"
-	},
-	{
-		"anonymous": false,
-		"inputs": [
-			{
-				"indexed": true,
-				"internalType": "address",
-				"name": "first",
-				"type": "address"
-			},
-			{
-				"indexed": false,
-				"internalType": "string",
-				"name": "second",
-				"type": "string"
-			}
-		],
-		"name": "EventAddressIdxString",
-		"type": "event"
-	},
-	{
-		"anonymous": false,
-		"inputs": [
-			{
-				"indexed": true,
-				"internalType": "address",
-				"name": "first",
-				"type": "address"
-			},
-			{
-				"indexed": false,
-				"internalType": "string",
-				"name": "second",
-				"type": "string"
-			},
-			{
-				"indexed": true,
-				"internalType": "uint256",
-				"name": "third",
-				"type": "uint256"
-			},
-			{
-				"indexed": false,
-				"internalType": "bytes",
-				"name": "fourth",
-				"type": "bytes"
-			}
-		],
-		"name": "EventAddressIdxStringUint256IdxBytes",
-		"type": "event"
-	},
-	{
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "first",
+        "type": "address"
+      }
+    ],
+    "name": "EventWithOverloads",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "string",
+        "name": "second",
+        "type": "string"
+      }
+    ],
+    "name": "EventWithOverloads",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "third",
+        "type": "uint256"
+      }
+    ],
+    "name": "EventWithOverloads",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "first",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "second",
+        "type": "string"
+      }
+    ],
+    "name": "EventAddressIdxString",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "first",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "second",
+        "type": "string"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "third",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "fourth",
+        "type": "bytes"
+      }
+    ],
+    "name": "EventAddressIdxStringUint256IdxBytes",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "first",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "second",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "third",
+        "type": "address"
+      }
+    ],
+    "name": "EventFixedBytesUintAddressIdx",
+    "type": "event"
+  },
+  {
     "anonymous": false,
     "inputs": [
       {
@@ -119,22 +144,22 @@
     "name": "EventAddressIdxUint256Uint256AddressIdx",
     "type": "event"
   },
-	{
-		"inputs": [
-			{
-				"internalType": "string",
-				"name": "first",
-				"type": "string"
-			},
-			{
-				"internalType": "string",
-				"name": "second",
-				"type": "string"
-			}
-		],
-		"name": "funStringString",
-		"outputs": [],
-		"stateMutability": "nonpayable",
-		"type": "function"
-	}
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "first",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "second",
+        "type": "string"
+      }
+    ],
+    "name": "funStringString",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
 ]

--- a/abigen-tests/abi/tests.json
+++ b/abigen-tests/abi/tests.json
@@ -110,7 +110,32 @@
         "type": "address"
       }
     ],
-    "name": "EventFixedBytesUintAddressIdx",
+    "name": "EventBytes32UintAddressIdx",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes20",
+        "name": "first",
+        "type": "bytes20"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "second",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "third",
+        "type": "address"
+      }
+    ],
+    "name": "EventBytes20UintAddressIdx",
     "type": "event"
   },
   {

--- a/abigen-tests/src/abi/tests.rs
+++ b/abigen-tests/src/abi/tests.rs
@@ -336,44 +336,153 @@
             }
         }
         #[derive(Debug, Clone, PartialEq)]
-        pub struct EventFixedBytesUintAddressIdx {
+        pub struct EventBytes20UintAddressIdx {
+            pub first: [u8; 20usize],
+            pub second: ethabi::Uint,
+            pub third: Vec<u8>,
+        }
+        impl EventBytes20UintAddressIdx {
+            const TOPIC_ID: [u8; 32] = [
+                130u8,
+                252u8,
+                100u8,
+                31u8,
+                27u8,
+                89u8,
+                229u8,
+                170u8,
+                29u8,
+                114u8,
+                181u8,
+                106u8,
+                121u8,
+                91u8,
+                106u8,
+                55u8,
+                182u8,
+                124u8,
+                76u8,
+                74u8,
+                112u8,
+                156u8,
+                148u8,
+                128u8,
+                139u8,
+                142u8,
+                18u8,
+                200u8,
+                60u8,
+                188u8,
+                147u8,
+                225u8,
+            ];
+            pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+                if log.topics.len() != 2usize {
+                    return false;
+                }
+                if log.data.len() != 64usize {
+                    return false;
+                }
+                return log.topics.get(0).expect("bounds already checked").as_ref()
+                    == Self::TOPIC_ID;
+            }
+            pub fn decode(
+                log: &substreams_ethereum::pb::eth::v2::Log,
+            ) -> Result<Self, String> {
+                let mut values = ethabi::decode(
+                        &[
+                            ethabi::ParamType::FixedBytes(20usize),
+                            ethabi::ParamType::Uint(256usize),
+                        ],
+                        log.data.as_ref(),
+                    )
+                    .map_err(|e| format!("unable to decode log.data: {}", e))?;
+                values.reverse();
+                Ok(Self {
+                    third: ethabi::decode(
+                            &[ethabi::ParamType::Address],
+                            log.topics[1usize].as_ref(),
+                        )
+                        .map_err(|e| {
+                            format!(
+                                "unable to decode param 'third' from topic of type 'address': {}",
+                                e
+                            )
+                        })?
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_address()
+                        .expect(INTERNAL_ERR)
+                        .as_bytes()
+                        .to_vec(),
+                    first: {
+                        let mut result = [0u8; 20];
+                        let v = values
+                            .pop()
+                            .expect(INTERNAL_ERR)
+                            .into_fixed_bytes()
+                            .expect(INTERNAL_ERR);
+                        result.copy_from_slice(&v);
+                        result
+                    },
+                    second: values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR),
+                })
+            }
+        }
+        impl substreams_ethereum::Event for EventBytes20UintAddressIdx {
+            const NAME: &'static str = "EventBytes20UintAddressIdx";
+            fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+                Self::match_log(log)
+            }
+            fn decode(
+                log: &substreams_ethereum::pb::eth::v2::Log,
+            ) -> Result<Self, String> {
+                Self::decode(log)
+            }
+        }
+        #[derive(Debug, Clone, PartialEq)]
+        pub struct EventBytes32UintAddressIdx {
             pub first: [u8; 32usize],
             pub second: ethabi::Uint,
             pub third: Vec<u8>,
         }
-        impl EventFixedBytesUintAddressIdx {
+        impl EventBytes32UintAddressIdx {
             const TOPIC_ID: [u8; 32] = [
-                52u8,
-                162u8,
-                190u8,
-                0u8,
-                149u8,
-                218u8,
-                4u8,
-                8u8,
-                30u8,
-                210u8,
-                117u8,
-                195u8,
-                147u8,
-                241u8,
-                253u8,
-                252u8,
-                96u8,
-                154u8,
+                168u8,
                 98u8,
-                39u8,
-                63u8,
-                255u8,
-                34u8,
-                49u8,
-                40u8,
-                92u8,
-                144u8,
-                109u8,
-                90u8,
-                148u8,
-                145u8,
+                190u8,
+                18u8,
+                161u8,
+                177u8,
+                122u8,
+                105u8,
+                123u8,
+                83u8,
+                68u8,
+                67u8,
+                62u8,
+                60u8,
+                188u8,
+                116u8,
+                76u8,
+                127u8,
+                158u8,
+                43u8,
+                11u8,
+                195u8,
+                155u8,
+                175u8,
+                77u8,
+                196u8,
+                9u8,
+                165u8,
+                168u8,
+                198u8,
+                176u8,
                 179u8,
             ];
             pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
@@ -433,8 +542,8 @@
                 })
             }
         }
-        impl substreams_ethereum::Event for EventFixedBytesUintAddressIdx {
-            const NAME: &'static str = "EventFixedBytesUintAddressIdx";
+        impl substreams_ethereum::Event for EventBytes32UintAddressIdx {
+            const NAME: &'static str = "EventBytes32UintAddressIdx";
             fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
                 Self::match_log(log)
             }

--- a/abigen-tests/src/lib.rs
+++ b/abigen-tests/src/lib.rs
@@ -36,14 +36,14 @@ mod tests {
     }
 
     #[test]
-    fn it_decode_event_fixed_bytes_uint_address_idx() {
-        use tests::events::EventFixedBytesUintAddressIdx as Event;
+    fn it_decode_event_bytes_32_uint_address_idx() {
+        use tests::events::EventBytes32UintAddressIdx as Event;
 
-        // ethc tools encode --abi ./abigen-tests/abi/tests.json event 'EventFixedBytesUintAddressIdx' "0x245414afb5b0fd4cd1285d0ff67e7d40218df67e1426c7e37c835cf2b5090cd2" "0x1000000000" "0xab07a50AD459B41Fe065f7BBAb866D5390e9f705"
+        // ethc tools encode --abi ./abigen-tests/abi/tests.json event 'EventBytes32UintAddressIdx' "0x245414afb5b0fd4cd1285d0ff67e7d40218df67e1426c7e37c835cf2b5090cd2" "0x1000000000" "0xab07a50AD459B41Fe065f7BBAb866D5390e9f705"
         let log = pb::eth::v2::Log {
             address: hex!("0000000000000000000000000000000000000000").to_vec(),
             topics: vec![
-                hex!("34a2be0095da04081ed275c393f1fdfc609a62273fff2231285c906d5a9491b3").to_vec(),
+                hex!("a862be12a1b17a697b5344433e3cbc744c7f9e2b0bc39baf4dc409a5a8c6b0b3").to_vec(),
                 hex!("000000000000000000000000ab07a50ad459b41fe065f7bbab866d5390e9f705").to_vec(),
             ],
             data: hex!("245414afb5b0fd4cd1285d0ff67e7d40218df67e1426c7e37c835cf2b5090cd20000000000000000000000000000000000000000000000000000001000000000").to_vec(),
@@ -58,6 +58,35 @@ mod tests {
             event,
             Ok(Event {
                 first: hex!("245414afb5b0fd4cd1285d0ff67e7d40218df67e1426c7e37c835cf2b5090cd2"),
+                second: U256::from_str_radix("0x1000000000", 16).unwrap(),
+                third: hex!("ab07a50ad459b41fe065f7bbab866d5390e9f705").to_vec()
+            }),
+        );
+    }
+
+    #[test]
+    fn it_decode_event_bytes_20_uint_address_idx() {
+        use tests::events::EventBytes20UintAddressIdx as Event;
+
+        // ethc tools encode --abi ./abigen-tests/abi/tests.json event 'EventBytes20UintAddressIdx' "0xab07a50ad459b41fe065f7bbab866d5390e9f705" "0x1000000000" "0xab07a50AD459B41Fe065f7BBAb866D5390e9f705"
+        let log = pb::eth::v2::Log {
+            address: hex!("0000000000000000000000000000000000000000").to_vec(),
+            topics: vec![
+                hex!("82fc641f1b59e5aa1d72b56a795b6a37b67c4c4a709c94808b8e12c83cbc93e1").to_vec(),
+                hex!("000000000000000000000000ab07a50ad459b41fe065f7bbab866d5390e9f705").to_vec(),
+            ],
+            data: hex!("ab07a50ad459b41fe065f7bbab866d5390e9f7050000000000000000000000000000000000000000000000000000000000000000000000000000001000000000").to_vec(),
+            ..Default::default()
+        };
+
+        assert_eq!(Event::match_log(&log), true);
+
+        let event = Event::decode(&log);
+
+        assert_eq!(
+            event,
+            Ok(Event {
+                first: hex!("ab07a50ad459b41fe065f7bbab866d5390e9f705"),
                 second: U256::from_str_radix("0x1000000000", 16).unwrap(),
                 third: hex!("ab07a50ad459b41fe065f7bbab866d5390e9f705").to_vec()
             }),

--- a/abigen-tests/src/lib.rs
+++ b/abigen-tests/src/lib.rs
@@ -36,6 +36,35 @@ mod tests {
     }
 
     #[test]
+    fn it_decode_event_fixed_bytes_uint_address_idx() {
+        use tests::events::EventFixedBytesUintAddressIdx as Event;
+
+        // ethc tools encode --abi ./abigen-tests/abi/tests.json event 'EventFixedBytesUintAddressIdx' "0x245414afb5b0fd4cd1285d0ff67e7d40218df67e1426c7e37c835cf2b5090cd2" "0x1000000000" "0xab07a50AD459B41Fe065f7BBAb866D5390e9f705"
+        let log = pb::eth::v2::Log {
+            address: hex!("0000000000000000000000000000000000000000").to_vec(),
+            topics: vec![
+                hex!("34a2be0095da04081ed275c393f1fdfc609a62273fff2231285c906d5a9491b3").to_vec(),
+                hex!("000000000000000000000000ab07a50ad459b41fe065f7bbab866d5390e9f705").to_vec(),
+            ],
+            data: hex!("245414afb5b0fd4cd1285d0ff67e7d40218df67e1426c7e37c835cf2b5090cd20000000000000000000000000000000000000000000000000000001000000000").to_vec(),
+            ..Default::default()
+        };
+
+        assert_eq!(Event::match_log(&log), true);
+
+        let event = Event::decode(&log);
+
+        assert_eq!(
+            event,
+            Ok(Event {
+                first: hex!("245414afb5b0fd4cd1285d0ff67e7d40218df67e1426c7e37c835cf2b5090cd2"),
+                second: U256::from_str_radix("0x1000000000", 16).unwrap(),
+                third: hex!("ab07a50ad459b41fe065f7bbab866d5390e9f705").to_vec()
+            }),
+        );
+    }
+
+    #[test]
     fn it_decode_event_address_idx_string_uint256_idx_bytes() {
         use tests::events::EventAddressIdxStringUint256IdxBytes as Event;
 

--- a/abigen/src/lib.rs
+++ b/abigen/src/lib.rs
@@ -126,8 +126,11 @@ fn rust_type(input: &ParamType) -> proc_macro2::TokenStream {
 
 fn fixed_data_size(input: &ParamType) -> Option<usize> {
     match *input {
-        ParamType::Address | ParamType::Int(_) | ParamType::Uint(_) | ParamType::Bool => Some(32),
-        ParamType::FixedBytes(byte_count) => Some(byte_count),
+        ParamType::Address
+        | ParamType::Int(_)
+        | ParamType::Uint(_)
+        | ParamType::Bool
+        | ParamType::FixedBytes(_) => Some(32),
         ParamType::Bytes | ParamType::String | ParamType::Array(_) => None,
         ParamType::FixedArray(_, _) if input.is_dynamic() => None,
         ParamType::FixedArray(ref sub_type, count) => {

--- a/abigen/src/lib.rs
+++ b/abigen/src/lib.rs
@@ -127,7 +127,7 @@ fn rust_type(input: &ParamType) -> proc_macro2::TokenStream {
 fn fixed_data_size(input: &ParamType) -> Option<usize> {
     match *input {
         ParamType::Address | ParamType::Int(_) | ParamType::Uint(_) | ParamType::Bool => Some(32),
-        ParamType::FixedBytes(byte_count) => Some((byte_count / 32) + 1),
+        ParamType::FixedBytes(byte_count) => Some(byte_count),
         ParamType::Bytes | ParamType::String | ParamType::Array(_) => None,
         ParamType::FixedArray(_, _) if input.is_dynamic() => None,
         ParamType::FixedArray(ref sub_type, count) => {


### PR DESCRIPTION
`FixedBytes` in `ethabi` have length equal to the actual length in bytes. Therefore, the `(byte_count / 32) + 1` seemed like a bug to me and was causing my substream to bug on `bytes32` fields in the events. 

I've removed the calculation and added an extra test as well.