### PR TITLE
Re-export block view module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 
 ## Next
 
+* Re-exporting `block_view` from `substreams-ethereum-core`
+
 ## [0.8.0](https://github.com/streaminfast/substreams-ethereum/releases/tag/v0.8.0)
 
 * Bump `substreams` crate

--- a/substreams-ethereum/src/lib.rs
+++ b/substreams-ethereum/src/lib.rs
@@ -1,5 +1,5 @@
 pub use substreams_ethereum_core::scalar;
-pub use substreams_ethereum_core::{pb, rpc, Event, Function, NULL_ADDRESS};
+pub use substreams_ethereum_core::{block_view, pb, rpc, Event, Function, NULL_ADDRESS};
 pub use substreams_ethereum_derive::EthabiContract;
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]


### PR DESCRIPTION
Just a quality-of-life re-export for building utils involving the various view structs without adding substreams-core to one's deps.