### PR TITLE
panic on event or function decode error after positive match

### DIFF
--- a/core/src/event.rs
+++ b/core/src/event.rs
@@ -17,15 +17,12 @@ pub trait Event: Sized {
 
         match Self::decode(&log) {
             Ok(event) => Some(event),
-            Err(err) => {
-                substreams::log::info!(
-                    "Log for event `{}` at index {} matched but failed to decode with error: {}",
-                    Self::NAME,
-                    log.block_index,
-                    err
-                );
-                None
-            }
+            Err(err) => panic!(
+                "Log for event `{}` at index {} matched but failed to decode with error: {}",
+                Self::NAME,
+                log.block_index,
+                err
+            ),
         }
     }
 }

--- a/core/src/function.rs
+++ b/core/src/function.rs
@@ -18,15 +18,12 @@ pub trait Function: Sized {
 
         match Self::decode(&call) {
             Ok(function) => Some(function),
-            Err(err) => {
-                substreams::log::info!(
-                    "Call for function `{}` at index {} matched but failed to decode with error: {}",
-                    Self::NAME,
-                    call.index,
-                    err
-                );
-                None
-            }
+            Err(err) => panic!(
+                "Call for function `{}` at index {} matched but failed to decode with error: {}",
+                Self::NAME,
+                call.index,
+                err
+            ),
         }
     }
 }


### PR DESCRIPTION
After a positive match, decoding should panic if there's an error. Unless I'm missing something, failing to decode after a positive match can only mean that there's an issue with the decoding logic. We wouldn't want to "silently" ignore matched events for such a reason, better to bubble up the error in that case. 