### PR TITLE
panic on rpc resonse decode error

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -44,14 +44,11 @@ impl RpcBatch {
 
         match T::output(response.raw.as_ref()) {
             Ok(data) => Some(data),
-            Err(err) => {
-                substreams::log::info!(
-                    "Call output for function `{}` failed to decode with error: {}",
-                    T::NAME,
-                    err
-                );
-                None
-            }
+            Err(err) => panic!(
+                "Call output for function `{}` failed to decode with error: {}",
+                T::NAME,
+                err
+            ),
         }
     }
 }


### PR DESCRIPTION
Same reason as https://github.com/streamingfast/substreams-ethereum/pull/13. Silently skipping decode error seems worse than just panicing there.